### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@
 // The details of what to fill in for this template are in the comments. So, read the source for this template to see the comments.
 //
 // Example title: Creating a RESTful web service
-= Testing on Open Liberty with the Arquillian Managed container
+= Testing with the Arquillian Managed container
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].


### PR DESCRIPTION
Per agreement with Laura and Alasdair we are removing Liberty from guide titles.  It's not necessary to include and allows titles to be more concise.