### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,8 +22,7 @@
 = Testing microservices with the Arquillian managed container
 
 [.hidden]
-NOTE: This repository contains the guide documentation source. To view the guide in published form,
-view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].
+NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].
 
 Learn how to develop tests for your microservices with the Arquillian managed container and run the tests on Open Liberty.
 


### PR DESCRIPTION
in cloud hosted, the short description is not located at the top of the first step