### PR TITLE
setting system.context.root defaultValue to "/"

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -32,7 +32,7 @@ public class SystemClient {
     private final String PROTOCOL = "http";
 
     @Inject
-    @ConfigProperty(name = "system.context.root", defaultValue = "")
+    @ConfigProperty(name = "system.context.root", defaultValue = "/")
     String SYSTEM_CONTEXT_ROOT;
 
     @Inject

--- a/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -32,7 +32,7 @@ public class SystemClient {
     private final String PROTOCOL = "http";
 
     @Inject
-    @ConfigProperty(name = "system.context.root", defaultValue = "")
+    @ConfigProperty(name = "system.context.root", defaultValue = "/")
     String SYSTEM_CONTEXT_ROOT;
 
     @Inject


### PR DESCRIPTION
After running `mvn liberty:dev` (including from prod) I am getting the following error:

```[INFO] [ERROR   ] CWWKZ0004E: An exception occurred while starting the application guide-arquillian-managed. The exception message was: com.ibm.ws.container.service.state.StateChangeException: org.jboss.weld.exceptions.DeploymentException: SRCFG02001: Failed to Inject @ConfigProperty for key system.context.root into io.openliberty.guides.inventory.client.SystemClient.SYSTEM_CONTEXT_ROOT SRCFG00040: The config property system.context.root is defined as the empty String ("") which the following Converter considered to be null: io.smallrye.config.Converters$BuiltInConverter```

There is also 2 test failures which are:

```
[ERROR] Failures: 
[ERROR]   InventoryArquillianIT.testInventoryEndpoints:88 Incorrect response code from http://localhost:9080/arquillian-managed/inventory/systems/localhost expected:<200> but was:<500>
[ERROR]   InventoryArquillianIT.testInventoryResourceFunctions:124 expected:<1> but was:<0>
[INFO] 
[ERROR] Tests run: 4, Failures: 2, Errors: 0, Skipped: 0
```

After setting the `system.context.root` `defaultValue="/"` instead of `defaultValue=""` There is no error on `mvn liberty:dev` nor there are any test failures. 