### PR TITLE
Make the cloud-hosted instruction clear

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,7 @@
 :projectid: arquillian-managed
 :page-duration: 15 minutes
 :page-releasedate: 2019-03-08
+:page-majorupdateddate: 2023-11-15
 :page-guide-category: none
 :page-description: Learn how to test your microservices with the Arquillian managed container and JUnit on Open Liberty.
 :guide-author: Open Liberty
@@ -40,10 +41,11 @@ include::{common-includes}/gitclone.adoc[]
 
 === Try what you'll build
 
-To try out the application, navigate to the `finish` directory and run the following commands:
+Run the following commands to navigate to the `finish` directory and run the tests:
 
 [role="command"]
 ----
+cd finish
 mvn clean package
 mvn liberty:create liberty:install-feature
 mvn liberty:configure-arquillian
@@ -181,10 +183,19 @@ The [hotspot=localConnector]`localConnector` feature is required by the Arquilli
 
 Open another command-line session and run the `configure-arquillian` goal from the `start` directory to integrate Arquillian and the Arquillian Liberty managed and remote containers with your existing project.
 
+ifndef::cloud-hosted[]
 [role="command"]
 ```
 mvn liberty:configure-arquillian
 ```
+endif::[]
+
+ifdef::cloud-hosted[]
+```bash
+cd /home/project/guide-arquillian-managed/start
+mvn liberty:configure-arquillian
+```
+endif::[]
 
 Because you started Open Liberty in dev mode, all the changes were automatically picked up. You can run the tests by pressing the `enter/return` key from the command-line session where you started dev mode. Look for the following output:
 


### PR DESCRIPTION
Add `cd` command to make the cloud-hosted instruction clear