### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <!-- arquillian configuration -->
         <!-- tag::ArquillianWarName[] -->
         <arquillian.war.name>arquillian-managed</arquillian.war.name>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.7.1.Final</version>
+                <version>1.8.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.5.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.5.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.5</version>
                 <configuration>
                   <systemPropertyVariables>
                     <arquillian.war.name>${arquillian.war.name}.war</arquillian.war.name>
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.9</version>
+                <version>3.10</version>
                 <configuration>
                   <!-- tag::arquillianProperties[] -->
                   <arquillianProperties>

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,8 +36,8 @@ public class SystemClient {
     String SYSTEM_CONTEXT_ROOT;
 
     @Inject
-    @ConfigProperty(name = "default.http.port")
-    String DEFAULT_PORT;
+    @ConfigProperty(name = "http.port")
+    String HTTP_PORT;
 
     // Wrapper function that gets properties
     public Properties getProperties(String hostname) {
@@ -58,7 +58,7 @@ public class SystemClient {
     // Method that creates the client builder
     private Builder getBuilder(String hostname, Client client) throws Exception {
         URI uri = new URI(
-                      PROTOCOL, null, hostname, Integer.valueOf(DEFAULT_PORT),
+                      PROTOCOL, null, hostname, Integer.valueOf(HTTP_PORT),
                       SYSTEM_CONTEXT_ROOT + SYSTEM_PROPERTIES, null, null);
         String urlString = uri.toString();
         Builder builder = client.target(urlString).request();

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -5,7 +5,7 @@
         <feature>jsonb-3.0</feature>
         <feature>jsonp-2.1</feature>
         <feature>cdi-4.0</feature>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
 
         <!--Enable the following features to run tests with Arquillian managed container-->
         <!-- tag::localConnector[] -->
@@ -17,11 +17,11 @@
         
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080" />
-    <variable name="default.https.port" defaultValue="9443" />
+    <variable name="http.port" defaultValue="9080" />
+    <variable name="https.port" defaultValue="9443" />
 
-    <httpEndpoint id="defaultHttpEndpoint" httpPort="${default.http.port}"
-        httpsPort="${default.https.port}" />
+    <httpEndpoint id="defaultHttpEndpoint" httpPort="${http.port}"
+        httpsPort="${https.port}" />
     <webApplication location="guide-arquillian-managed.war"
         context-root="/" />
 </server>

--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -8,7 +8,7 @@ do
     esac
 done
 
-sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#,\#<configuration>#c<artifactId>liberty-maven-plugin</artifactId><version>3.7.1</version><configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install>" pom.xml
+sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#,\#<configuration>#c<artifactId>liberty-maven-plugin</artifactId><version>3.10</version><configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install>" pom.xml
 cat pom.xml
 
 ../scripts/testApp.sh

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <!-- arquillian configuration -->
         <!-- tag::ArquillianWarName[] -->
         <arquillian.war.name>arquillian-managed</arquillian.war.name>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.7.1.Final</version>
+                <version>1.8.0.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.5.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.5.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.5</version>
                 <configuration>
                   <systemPropertyVariables>
                     <arquillian.war.name>${arquillian.war.name}.war</arquillian.war.name>
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.9</version>
+                <version>3.10</version>
                 <configuration>
                   <!-- tag::arquillianProperties[] -->
                   <arquillianProperties>

--- a/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,8 +36,8 @@ public class SystemClient {
     String SYSTEM_CONTEXT_ROOT;
 
     @Inject
-    @ConfigProperty(name = "default.http.port")
-    String DEFAULT_PORT;
+    @ConfigProperty(name = "http.port")
+    String HTTP_PORT;
 
     // Wrapper function that gets properties
     public Properties getProperties(String hostname) {
@@ -58,7 +58,7 @@ public class SystemClient {
     // Method that creates the client builder
     private Builder getBuilder(String hostname, Client client) throws Exception {
         URI uri = new URI(
-                      PROTOCOL, null, hostname, Integer.valueOf(DEFAULT_PORT),
+                      PROTOCOL, null, hostname, Integer.valueOf(HTTP_PORT),
                       SYSTEM_CONTEXT_ROOT + SYSTEM_PROPERTIES, null, null);
         String urlString = uri.toString();
         Builder builder = client.target(urlString).request();

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -5,7 +5,7 @@
         <feature>jsonb-3.0</feature>
         <feature>jsonp-2.1</feature>
         <feature>cdi-4.0</feature>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
 
         <!-- Enable the following features to run tests with Arquillian managed container -->
         <!-- tag::localConnector[] -->
@@ -17,11 +17,11 @@
 
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9080" />
-    <variable name="default.https.port" defaultValue="9443" />
+    <variable name="http.port" defaultValue="9080" />
+    <variable name="https.port" defaultValue="9443" />
 
-    <httpEndpoint id="defaultHttpEndpoint" httpPort="${default.http.port}"
-        httpsPort="${default.https.port}" />
+    <httpEndpoint id="defaultHttpEndpoint" httpPort="${http.port}"
+        httpsPort="${https.port}" />
     <webApplication location="guide-arquillian-managed.war"
         context-root="/" />
 </server>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

